### PR TITLE
Fix zone detection for cross-zone cnames

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -258,8 +258,10 @@ func FindZoneByFqdn(fqdn string, nameservers []string) (string, error) {
 			for _, ans := range in.Answer {
 				if soa, ok := ans.(*dns.SOA); ok {
 					zone := soa.Hdr.Name
-					fqdnToZone[fqdn] = zone
-					return zone, nil
+					if strings.HasSuffix(domain, zone) {
+						fqdnToZone[fqdn] = zone
+						return zone, nil
+					}
 				}
 			}
 		}

--- a/acme/dns_challenge_test.go
+++ b/acme/dns_challenge_test.go
@@ -43,9 +43,10 @@ var findZoneByFqdnTests = []struct {
 	fqdn string
 	zone string
 }{
-	{"mail.google.com.", "google.com."}, // domain is a CNAME
-	{"foo.google.com.", "google.com."},  // domain is a non-existent subdomain
-	{"example.com.ac.", "ac."},          // domain is a eTLD
+	{"mail.google.com.", "google.com."},            // domain is a CNAME
+	{"foo.google.com.", "google.com."},             // domain is a non-existent subdomain
+	{"example.com.ac.", "ac."},                     // domain is a eTLD
+	{"console.aws.amazon.com.", "aws.amazon.com."}, // domain is a cross-zone CNAME
 }
 
 var checkAuthoritativeNssTests = []struct {


### PR DESCRIPTION
When a SOA record's name is not a suffix of the domain it should be ignored.

See #330